### PR TITLE
Use different way to define stimulus

### DIFF
--- a/src/simcardems/ep_model.py
+++ b/src/simcardems/ep_model.py
@@ -63,25 +63,15 @@ def setup_ep_model(cellmodel, mesh):
     factor = 1.0 / (chi * C_m)  # NB: cbcbeat convention
     amplitude = factor * A * (1.0 / cm2mm) ** 3  # mV/ms
     PCL = 1000  # Pacing cycle length [ms]
-    stimulus_times = list(range(0, 200000, PCL))  # Stimulus applied at each
-    # stimulus_times = [0,20,40] # Stimulus applied at t=0, t=20 and t=40ms
-    s = "0.0"
-    for t in reversed(stimulus_times):
-        s = (
-            "(time >= start + "
-            + str(t)
-            + " ? (time <= (duration + start + "
-            + str(t)
-            + ") ? amplitude : "
-            + s
-            + ") : 0.0 )"
-        )
+    s = "((std::fmod(time,PCL) >= start) & (std::fmod(time,PCL) <= duration + start)) ? amplitude : 0.0"
+
     I_s = dolfin.Expression(
         s,
         time=time,
         start=0.0,
         duration=duration,
         amplitude=amplitude,
+        PCL=PCL,
         degree=0,
     )
     # Store input parameters in cardiac model


### PR DESCRIPTION
When defining the stimulus by concatenating the strings for each interval we run into an issue when the string is too long (there is possibly som limit of how large this string can be). Here I simply define the stimulus by just doing a moduls of the time with respect to the cycle length and then checking whether that is between the `start` and `start + duration`.