### PR TITLE
Make sure we use the correct dt in the mechanics model

### DIFF
--- a/src/simcardems/em_model.py
+++ b/src/simcardems/em_model.py
@@ -33,7 +33,7 @@ class EMCoupling:
         self.lmbda_ep = dolfin.Function(self.V_ep, name="lambda_ep")
         self.Zetas_ep = dolfin.Function(self.V_ep, name="Zetas_ep")
         self.Zetaw_ep = dolfin.Function(self.V_ep, name="Zetaw_ep")
-        self.interpolate_ep()
+        self.mechanics_to_coupling()
 
     @property
     def mech_mesh(self):
@@ -49,31 +49,31 @@ class EMCoupling:
         self.vs = solver.solution_fields()[0]
         self.XS_ep, self.XS_ep_assigner = utils.setup_assigner(self.vs, 40)
         self.XW_ep, self.XW_ep_assigner = utils.setup_assigner(self.vs, 41)
-        self.interpolate_mechanics()
+        self.coupling_to_mechanics
         logger.debug("Done registering EP model")
 
-    def update_mechanics(self):
+    def ep_to_coupling(self):
         logger.debug("Update mechanics")
         self.XS_ep_assigner.assign(self.XS_ep, utils.sub_function(self.vs, 40))
         self.XW_ep_assigner.assign(self.XW_ep, utils.sub_function(self.vs, 41))
         logger.debug("Done updating mechanics")
 
-    def interpolate_mechanics(self):
+    def coupling_to_mechanics(self):
         logger.debug("Interpolate mechanics")
         self.XS_mech.assign(dolfin.interpolate(self.XS_ep, self.V_mech))
         self.XW_mech.assign(dolfin.interpolate(self.XW_ep, self.V_mech))
         logger.debug("Done interpolating mechanics")
 
-    def update_ep(self):
-        logger.debug("Update EP")
-        dolfin.assign(utils.sub_function(self._ep_solver.vs, 46), self.lmbda_ep)
-        dolfin.assign(utils.sub_function(self._ep_solver.vs, 47), self.Zetas_ep)
-        dolfin.assign(utils.sub_function(self._ep_solver.vs, 48), self.Zetaw_ep)
-        logger.debug("Done updating EP")
-
-    def interpolate_ep(self):
+    def mechanics_to_coupling(self):
         logger.debug("Interpolate EP")
         self.lmbda_ep.assign(dolfin.interpolate(self.lmbda_mech, self.V_ep))
         self.Zetas_ep.assign(dolfin.interpolate(self.Zetas_mech, self.V_ep))
         self.Zetaw_ep.assign(dolfin.interpolate(self.Zetaw_mech, self.V_ep))
         logger.debug("Done interpolating EP")
+
+    def coupling_to_ep(self):
+        logger.debug("Update EP")
+        dolfin.assign(utils.sub_function(self._ep_solver.vs, 46), self.lmbda_ep)
+        dolfin.assign(utils.sub_function(self._ep_solver.vs, 47), self.Zetas_ep)
+        dolfin.assign(utils.sub_function(self._ep_solver.vs, 48), self.Zetaw_ep)
+        logger.debug("Done updating EP")

--- a/src/simcardems/mechanics_model.py
+++ b/src/simcardems/mechanics_model.py
@@ -21,7 +21,6 @@ class LandModel(pulse.ActiveModel):
         self,
         XS,
         XW,
-        dt,
         lmbda,
         Zetas,
         Zetaw,
@@ -42,7 +41,8 @@ class LandModel(pulse.ActiveModel):
         self.XW = XW
         self.XW_prev = dolfin.Function(function_space)
         self._parameters = parameters
-        self.dt = dt
+        self.t = 0.0
+        self._t_prev = 0.0
 
         self.Zetas = Zetas
         self.Zetaw = Zetaw
@@ -58,6 +58,14 @@ class LandModel(pulse.ActiveModel):
         self.lmbda_current = dolfin.Function(function_space)
         self.lmbda_current = lmbda
         self.update_prev()
+
+    @property
+    def dt(self):
+        return self.t - self._t_prev
+
+    def update_time(self, t):
+        self._t_prev = self.t
+        self.t = t
 
     def update_prev(self):
         self.XS_prev.vector()[:] = self.XS.vector()
@@ -78,6 +86,11 @@ class LandModel(pulse.ActiveModel):
         return dLambda
 
     def _solve_ode(self, F):
+
+        Zetas = self.Zetas
+        Zetaw = self.Zetaw
+        if abs(self.dt) < 1e-10:
+            return Zetas, Zetaw
 
         phi = self._parameters["phi"]
         Tot_A = self._parameters["Tot_A"]
@@ -120,17 +133,14 @@ class LandModel(pulse.ActiveModel):
         # dZetaw = self.dLambda * Aw - self.Zetaw * cw
 
         # Lets use Backward Euler scheme with a few fixed point iterations
-        Zetas = self.Zetas
-        Zetaw = self.Zetaw
 
-        for _ in range(10):
-            Zetas = self.Zetas_prev + self.dt * (self.dLambda(F) * As - Zetas * cs)
-            Zetaw = self.Zetaw_prev + self.dt * (self.dLambda(F) * Aw - Zetaw * cw)
+        Zetas = self.Zetas_prev + self.dt * (self.dLambda(F) * As - Zetas * cs)
+        Zetaw = self.Zetaw_prev + self.dt * (self.dLambda(F) * Aw - Zetaw * cw)
 
         return Zetas, Zetaw
 
     def Ta(self, F):
-
+        print("dt = ", self.dt, "t = ", self.t, "t_prev =", self._t_prev)
         Zetas, Zetaw = self._solve_ode(F)
         Tref = self._parameters["Tref"]
         rs = self._parameters["rs"]

--- a/src/simcardems/setup_models.py
+++ b/src/simcardems/setup_models.py
@@ -98,7 +98,6 @@ def setup_EM_model(
 
     mech_heart = setup_mechanics_solver(
         coupling=coupling,
-        dt=dt,
         bnd_cond=bnd_cond,
         cell_params=solver.ode_solver._model.parameters(),
         pre_stretch=pre_stretch,
@@ -118,7 +117,6 @@ def setup_EM_model(
 
 def setup_mechanics_solver(
     coupling: em_model.EMCoupling,
-    dt,
     bnd_cond: mechanics_model.BoundaryConditions,
     cell_params,
     pre_stretch: typing.Optional[typing.Union[dolfin.Constant, float]] = None,
@@ -175,7 +173,6 @@ def setup_mechanics_solver(
         parameters=cell_params,
         XS=coupling.XS_mech,
         XW=coupling.XW_mech,
-        dt=dt,
         function_space=V,
     )
     material = pulse.HolzapfelOgden(
@@ -430,24 +427,28 @@ class Runner:
     def _solve_mechanics_now(self) -> bool:
 
         # Update these states that are needed in the Mechanics solver
-        self.coupling.update_mechanics()
+        self.coupling.ep_to_coupling()
 
         XS_norm = utils.compute_norm(self.coupling.XS_ep, self._pre_XS)
         XW_norm = utils.compute_norm(self.coupling.XW_ep, self._pre_XW)
 
-        return XS_norm + XW_norm >= 0.1
+        # dt for the mechanics model should not be larger than 1 ms
+        dt = self._t - self.mech_heart.material.active.t
+
+        return (XS_norm + XW_norm >= 0.1) or dt > 1.0
 
     def _pre_mechanics_solve(self) -> None:
         self._preXS_assigner.assign(self._pre_XS, utils.sub_function(self._vs, 40))
         self._preXW_assigner.assign(self._pre_XW, utils.sub_function(self._vs, 41))
 
-        self.coupling.interpolate_mechanics()
+        self.coupling.coupling_to_mechanics()
+        self.mech_heart.material.active.update_time(self._t)
 
     def _post_mechanics_solve(self) -> None:
-        self.coupling.interpolate_ep()
+        self.coupling.mechanics_to_coupling()
         # Update previous active tension
         self.mech_heart.material.active.update_prev()
-        self.coupling.update_ep()
+        self.coupling.coupling_to_ep()
 
     def _solve_mechanics(self):
         self._pre_mechanics_solve()


### PR DESCRIPTION
Somehow we were using the same `dt` in the mechanics model as in the EP model. This is of course true if we solve the mechanics model at each step, but if we use an adaptive stepping, then this is not true any more. 

In this PR we make sure to use the correct `dt` for the mechanics model. We also change to names of the methods in the EM model to something a bit more descriptive.