### PR TITLE
Initialize lmbda_prev with 1.0 instead of 0.0

### DIFF
--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -56,6 +56,7 @@ class LandModel(pulse.ActiveModel):
 
         self._dLambda = dolfin.Function(self.function_space)
         self.lmbda_prev = dolfin.Function(self.function_space)
+        self.lmbda_prev.vector()[:] = 1.0
         if lmbda is not None:
             self.lmbda_prev = lmbda
         self.lmbda = dolfin.Function(self.function_space)


### PR DESCRIPTION
Initialize `lambda_prev` in `Land model` with 1.0 instead of 0.0. 
When initialised with `lambda_prev=0.0`, the first step is very large for all mechanics variables. 

