### PR TITLE
Replace hpc option by show_progress_bar/hide_progress_bar

### DIFF
--- a/demos/simple_demo.py
+++ b/demos/simple_demo.py
@@ -31,7 +31,7 @@ config = simcardems.Config(outdir=outdir)
 #  'ep_preconditioner': 'sor',
 #  'ep_theta': 0.5,
 #  'fix_right_plane': False,
-#  'hpc': False,
+#  'show_progress_bar': True,
 #  'linear_mechanics_solver': 'mumps',
 #  'load_state': False,
 #  'loglevel': 20,
@@ -55,7 +55,7 @@ config = simcardems.Config(outdir=outdir)
 pprint.pprint(config.as_dict())
 
 runner = simcardems.Runner(config)
-runner.solve(T=config.T, save_freq=config.save_freq)
+runner.solve(T=config.T, save_freq=config.save_freq, show_progress_bar=True)
 
 
 # This will create the output directory `results_simple_demo` with the following output

--- a/demos/simple_demo.py
+++ b/demos/simple_demo.py
@@ -51,12 +51,11 @@ config = simcardems.Config(outdir=outdir)
 #  'traction': None}
 # ```
 
-
 # Print current configuration
 pprint.pprint(config.as_dict())
 
 runner = simcardems.Runner(config)
-runner.solve(T=config.T, save_freq=config.save_freq, hpc=False)
+runner.solve(T=config.T, save_freq=config.save_freq)
 
 
 # This will create the output directory `results_simple_demo` with the following output

--- a/src/simcardems/benchmark.py
+++ b/src/simcardems/benchmark.py
@@ -39,7 +39,7 @@ def main(outdir):
     t0 = time.perf_counter()
 
     if runner.t0 < config.T:
-        runner.solve(T=config.T, save_freq=config.save_freq)
+        runner.solve(T=config.T, save_freq=config.save_freq, show_progress_bar=False)
     data["solve_time"] = time.perf_counter() - t0
 
     loader = simcardems.DataLoader(Path(outdir) / "results.h5")

--- a/src/simcardems/benchmark.py
+++ b/src/simcardems/benchmark.py
@@ -39,7 +39,7 @@ def main(outdir):
     t0 = time.perf_counter()
 
     if runner.t0 < config.T:
-        runner.solve(T=config.T, save_freq=config.save_freq, hpc=False)
+        runner.solve(T=config.T, save_freq=config.save_freq)
     data["solve_time"] = time.perf_counter() - t0
 
     loader = simcardems.DataLoader(Path(outdir) / "results.h5")

--- a/src/simcardems/cli.py
+++ b/src/simcardems/cli.py
@@ -106,6 +106,11 @@ def cli():
     help="How much printing. DEBUG: 10, INFO:20 (default), WARNING: 30",
 )
 @click.option(
+    "--show_progress_bar/--hide_progress_bar",
+    default=Config.show_progress_bar,
+    help="Shows or hide the progress bar.",
+)
+@click.option(
     "--drug_factors_file",
     default=Config.drug_factors_file,
     type=str,
@@ -167,6 +172,7 @@ def run(
     bnd_cond: mechanics_model.BoundaryConditions,
     load_state: bool,
     cell_init_file: utils.PathLike,
+    show_progress_bar: bool,
     lx: float,
     ly: float,
     lz: float,
@@ -195,6 +201,7 @@ def run(
         traction=traction,
         load_state=load_state,
         cell_init_file=cell_init_file,
+        show_progress_bar=show_progress_bar,
         lx=lx,
         ly=ly,
         lz=lz,
@@ -242,7 +249,11 @@ def main(config: typing.Optional[Config]):
 
     runner = Runner(config=config)
 
-    runner.solve(T=config.T, save_freq=config.save_freq)
+    runner.solve(
+        T=config.T,
+        save_freq=config.save_freq,
+        show_progress_bar=config.show_progress_bar,
+    )
 
 
 @click.command("postprocess")

--- a/src/simcardems/cli.py
+++ b/src/simcardems/cli.py
@@ -106,12 +106,6 @@ def cli():
     help="How much printing. DEBUG: 10, INFO:20 (default), WARNING: 30",
 )
 @click.option(
-    "--hpc",
-    is_flag=True,
-    default=Config.hpc,
-    help="Indicate if simulations runs on hpc. This turns off the progress bar.",
-)
-@click.option(
     "--drug_factors_file",
     default=Config.drug_factors_file,
     type=str,
@@ -173,7 +167,6 @@ def run(
     bnd_cond: mechanics_model.BoundaryConditions,
     load_state: bool,
     cell_init_file: utils.PathLike,
-    hpc: bool,
     lx: float,
     ly: float,
     lz: float,
@@ -202,7 +195,6 @@ def run(
         traction=traction,
         load_state=load_state,
         cell_init_file=cell_init_file,
-        hpc=hpc,
         lx=lx,
         ly=ly,
         lz=lz,
@@ -250,7 +242,7 @@ def main(config: typing.Optional[Config]):
 
     runner = Runner(config=config)
 
-    runner.solve(T=config.T, save_freq=config.save_freq, hpc=config.hpc)
+    runner.solve(T=config.T, save_freq=config.save_freq)
 
 
 @click.command("postprocess")

--- a/src/simcardems/config.py
+++ b/src/simcardems/config.py
@@ -20,7 +20,6 @@ class Config:
     )
     load_state: bool = False
     cell_init_file: utils.PathLike = ""
-    hpc: bool = False
     lx: float = 2.0
     ly: float = 0.7
     lz: float = 0.3

--- a/src/simcardems/config.py
+++ b/src/simcardems/config.py
@@ -20,6 +20,7 @@ class Config:
     )
     load_state: bool = False
     cell_init_file: utils.PathLike = ""
+    show_progress_bar: bool = True
     lx: float = 2.0
     ly: float = 0.7
     lz: float = 0.3

--- a/src/simcardems/setup_models.py
+++ b/src/simcardems/setup_models.py
@@ -498,7 +498,6 @@ class Runner:
         self,
         T: float = Config.T,
         save_freq: int = Config.save_freq,
-        hpc: bool = Config.hpc,
         st_progress: typing.Any = None,
     ):
         if not hasattr(self, "_outdir"):
@@ -512,7 +511,7 @@ class Runner:
 
         save_it = int(save_freq / self._dt)
         self.create_time_stepper(T, use_ns=True, st_progress=st_progress)
-        pbar = create_progressbar(time_stepper=self._time_stepper, hpc=hpc)
+        pbar = create_progressbar(time_stepper=self._time_stepper)
 
         # Store initial state
         save_state_every_n_beat = 5  # Save state every fifth beat
@@ -713,8 +712,8 @@ class TimeStepper:
 
 def create_progressbar(
     time_stepper: TimeStepper,
-    hpc: bool = Config.hpc,
 ):
+    hpc = bool(dolfin.MPI.size(dolfin.MPI.comm_world) > 1)
     if hpc:
         # Turn off progressbar
         pbar = _tqdm(time_stepper, total=time_stepper.total_steps)

--- a/src/simcardems/setup_models.py
+++ b/src/simcardems/setup_models.py
@@ -498,6 +498,7 @@ class Runner:
         self,
         T: float = Config.T,
         save_freq: int = Config.save_freq,
+        show_progress_bar: bool = Config.show_progress_bar,
         st_progress: typing.Any = None,
     ):
         if not hasattr(self, "_outdir"):
@@ -511,7 +512,10 @@ class Runner:
 
         save_it = int(save_freq / self._dt)
         self.create_time_stepper(T, use_ns=True, st_progress=st_progress)
-        pbar = create_progressbar(time_stepper=self._time_stepper)
+        pbar = create_progressbar(
+            time_stepper=self._time_stepper,
+            show_progress_bar=show_progress_bar,
+        )
 
         # Store initial state
         save_state_every_n_beat = 5  # Save state every fifth beat
@@ -712,11 +716,12 @@ class TimeStepper:
 
 def create_progressbar(
     time_stepper: TimeStepper,
+    show_progress_bar: bool = Config.show_progress_bar,
 ):
-    hpc = bool(dolfin.MPI.size(dolfin.MPI.comm_world) > 1)
-    if hpc:
-        # Turn off progressbar
-        pbar = _tqdm(time_stepper, total=time_stepper.total_steps)
-    else:
+    if show_progress_bar:
+        # Show progressbar
         pbar = tqdm(time_stepper, total=time_stepper.total_steps)
+    else:
+        # Hide progressbar
+        pbar = _tqdm(time_stepper, total=time_stepper.total_steps)
     return pbar


### PR DESCRIPTION
Fixes #87

## Proposed Changes
  ~~Remove hpc option - replaced by checking size of the global communicator to trun off progress bar if needed~~
   Remove hpc option - replaced by `--show_progress_bar` / `--hide_progress_bar`, to be more explicit
