### PR TITLE
Adapt ffun and recreate microstructure if using qudrature spaces

### DIFF
--- a/src/simcardems/geometry.py
+++ b/src/simcardems/geometry.py
@@ -54,6 +54,7 @@ def refine_mesh(
     redistribute: bool = False,
 ) -> dolfin.Mesh:
 
+    dolfin.parameters["refinement_algorithm"] = "plaza_with_parent_facets"
     for i in range(num_refinements):
         logger.info(f"Performing refinement {i+1}")
         mesh = dolfin.refine(mesh, redistribute=redistribute)
@@ -93,6 +94,7 @@ class BaseGeometry(abc.ABC):
         microstructure: Optional[pulse.Microstructure] = None,
         microstructure_ep: Optional[pulse.Microstructure] = None,
         ffun: Optional[dolfin.MeshFunction] = None,
+        ffun_ep: Optional[dolfin.MeshFunction] = None,
         markers: Optional[Dict[str, Tuple[int, int]]] = None,
         outdir: Optional[utils.PathLike] = None,
     ) -> None:
@@ -107,9 +109,10 @@ class BaseGeometry(abc.ABC):
             self.parameters.update(parameters)
 
         self.mechanics_mesh = mechanics_mesh
-        self.ep_mesh = ep_mesh
-
         self.ffun = ffun
+        self.ep_mesh = ep_mesh
+        self.ffun_ep = ffun_ep
+
         self.microstructure = microstructure
         self.microstructure_ep = microstructure_ep
         self.validate()
@@ -149,6 +152,12 @@ class BaseGeometry(abc.ABC):
                 is_meshfunction=True,
                 dim=2,
                 mesh_key="mesh",
+            ),
+            "ffun_ep": H5Path(
+                h5group="/geometry/meshfunctions/ffun_ep",
+                is_meshfunction=True,
+                dim=2,
+                mesh_key="ep_mesh",
             ),
             "f0": H5Path(
                 h5group="/geometry/microstructure/mechanics/f0",
@@ -193,8 +202,8 @@ class BaseGeometry(abc.ABC):
     @abc.abstractmethod
     def _default_microstructure(
         self,
-        fiber_space: str,
         mesh: dolfin.Mesh,
+        ffun: dolfin.MeshFunction,
     ) -> pulse.Microstructure:
         ...
 
@@ -248,12 +257,10 @@ class BaseGeometry(abc.ABC):
     def _get_microstructure_if_None(
         self,
         mesh: dolfin.Mesh,
+        ffun: dolfin.MeshFunction,
         label: str,
     ) -> pulse.Microstructure:
-        microstructure = self._default_microstructure(
-            fiber_space=self.parameters["fiber_space"],
-            mesh=mesh,
-        )
+        microstructure = self._default_microstructure(mesh=mesh, ffun=ffun)
 
         if self.outdir is not None:
             path = self.outdir / f"microstructure{label}.h5"
@@ -273,17 +280,21 @@ class BaseGeometry(abc.ABC):
 
     @microstructure_ep.setter
     def microstructure_ep(self, microstructure: Optional[pulse.Microstructure]) -> None:
-        if microstructure is None:
+        if microstructure is None or microstructure.f0 is None:
             microstructure = self._interpolate_microstructure()
         self._microstructure_ep = microstructure
 
     def _interpolate_microstructure(self) -> pulse.Microstructure:
         element = self.f0.ufl_element()
-        V = dolfin.FunctionSpace(self.ep_mesh, element)
-        f0 = dolfin.interpolate(self.f0, V)
-        s0 = dolfin.interpolate(self.s0, V)
-        n0 = dolfin.interpolate(self.n0, V)
-        return pulse.Microstructure(f0=f0, s0=s0, n0=n0)
+        if element.family() == "Quadrature":
+            return self._default_microstructure(mesh=self.ep_mesh, ffun=self.ffun_ep)
+        else:
+            V = dolfin.FunctionSpace(self.ep_mesh, element)
+
+            f0 = dolfin.interpolate(self.f0, V)
+            s0 = dolfin.interpolate(self.s0, V)
+            n0 = dolfin.interpolate(self.n0, V)
+            return pulse.Microstructure(f0=f0, s0=s0, n0=n0)
 
     @property
     def microstructure(self) -> pulse.Microstructure:
@@ -294,6 +305,7 @@ class BaseGeometry(abc.ABC):
         if microstructure is None:
             microstructure = self._get_microstructure_if_None(
                 mesh=self.mechanics_mesh,
+                ffun=self.ffun,
                 label="",
             )
         self._microstructure = microstructure
@@ -361,8 +373,8 @@ class BaseGeometry(abc.ABC):
     def ep_mesh(self, mesh: Optional[dolfin.Mesh]) -> None:
         if mesh is None:
             self._ep_mesh = refine_mesh(
-                self.mechanics_mesh,
-                self.parameters["num_refinements"],
+                mesh=self.mechanics_mesh,
+                num_refinements=self.parameters["num_refinements"],
             )
             if self.outdir is not None:
                 mesh_path = self.outdir / "ep_mesh.xdmf"
@@ -371,6 +383,18 @@ class BaseGeometry(abc.ABC):
 
         else:
             self._ep_mesh = mesh
+
+    @property
+    def ffun_ep(self) -> dolfin.MeshFunction:
+        return self._ffun_ep  # type: ignore
+
+    @ffun_ep.setter
+    def ffun_ep(self, ffun: Optional[dolfin.MeshFunction]) -> None:
+        if ffun is None:
+            self._ffun_ep = dolfin.adapt(self.ffun, self.ep_mesh)
+        else:
+            self._ffun_ep = ffun
+        dolfin.File("ffun_ep.pvd") << self._ffun_ep
 
     @property
     def outdir(self) -> Optional[Path]:
@@ -461,6 +485,7 @@ class BaseGeometry(abc.ABC):
             ("ep_mesh", "ep_mesh"),
             ("markers", "markers"),
             ("ffun", "ffun"),
+            ("ffun_ep", "ffun_ep"),
         ]:
             attr = getattr(geo, attr_geo, None)
             if attr is not None:
@@ -497,10 +522,19 @@ class SlabGeometry(BaseGeometry):
 
     def _default_microstructure(
         self,
-        fiber_space: str,
         mesh: dolfin.Mesh,
+        ffun: dolfin.MeshFunction,
     ) -> pulse.Microstructure:
-        return create_slab_microstructure(fiber_space=fiber_space, mesh=mesh)
+        from cardiac_geometries import slab_fibers
+
+        return slab_fibers.create_microstructure(
+            function_space=self.parameters["fiber_space"],
+            mesh=mesh,
+            ffun=ffun,
+            markers=self.markers,
+            alpha_endo=self.parameters["fibers_angle_endo"],
+            alpha_epi=self.parameters["fibers_angle_epi"],
+        )
 
     def _default_ffun(self, mesh: dolfin.Mesh) -> dolfin.MeshFunction:
         return create_slab_facet_function(
@@ -525,7 +559,9 @@ class SlabGeometry(BaseGeometry):
             ly=0.7,
             lz=0.3,
             dx=0.2,
-            fiber_space="DG_1",
+            fibers_angle_endo=0,
+            fibers_angle_epi=0,
+            fiber_space="Quadrature_3",
             num_refinements=1,
             mesh_type=MeshTypes.slab.value,
         )
@@ -567,39 +603,6 @@ def create_slab_facet_function(
     return ffun
 
 
-def create_slab_microstructure(fiber_space, mesh):
-
-    family, degree = fiber_space.split("_")
-    logger.debug("Set up microstructure")
-    V_f = dolfin.VectorFunctionSpace(mesh, family, int(degree))
-    f0 = dolfin.interpolate(
-        dolfin.Expression(
-            ("1.0", "0.0", "0.0"),
-            degree=1,
-            cell=mesh.ufl_cell(),
-        ),
-        V_f,
-    )
-    s0 = dolfin.interpolate(
-        dolfin.Expression(
-            ("0.0", "1.0", "0.0"),
-            degree=1,
-            cell=mesh.ufl_cell(),
-        ),
-        V_f,
-    )
-    n0 = dolfin.interpolate(
-        dolfin.Expression(
-            ("0.0", "0.0", "1.0"),
-            degree=1,
-            cell=mesh.ufl_cell(),
-        ),
-        V_f,
-    )
-    # Collect the microstructure
-    return pulse.Microstructure(f0=f0, s0=s0, n0=n0)
-
-
 class LeftVentricularGeometry(BaseGeometry):
     @staticmethod
     def default_markers() -> Dict[str, Tuple[int, int]]:
@@ -611,10 +614,23 @@ class LeftVentricularGeometry(BaseGeometry):
 
     def _default_microstructure(
         self,
-        fiber_space: str,
         mesh: dolfin.Mesh,
+        ffun: dolfin.MeshFunction,
     ) -> pulse.Microstructure:
-        raise NotImplementedError
+        from cardiac_geometries import lv_ellipsoid_fibers
+
+        return lv_ellipsoid_fibers.create_microstructure(
+            function_space=self.parameters["fiber_space"],
+            mesh=mesh,
+            ffun=ffun,
+            markers=self.markers,
+            r_short_endo=self.parameters["r_short_endo"],
+            r_short_epi=self.parameters["r_short_epi"],
+            r_long_endo=self.parameters["r_long_endo"],
+            r_long_epi=self.parameters["r_long_epi"],
+            alpha_endo=self.parameters["fibers_angle_endo"],
+            alpha_epi=self.parameters["fibers_angle_epi"],
+        )
 
     def _default_ffun(self, mesh: dolfin.Mesh) -> dolfin.MeshFunction:
         raise NotImplementedError
@@ -626,7 +642,7 @@ class LeftVentricularGeometry(BaseGeometry):
     def default_parameters():
         return {
             "num_refinements": 1,
-            "fiber_space": "P_1",
+            "fiber_space": "Quadrature_3",
             "fibers_angle_endo": -60.0,
             "fibers_angle_epi": 60.0,
             "mesh_type": MeshTypes.lv_ellipsoid.value,

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -217,7 +217,6 @@ class LandModel(pulse.ActiveModel):
             dolfin.project(
                 dolfin.sqrt(f**2),
                 self.cg1_space,
-                form_compiler_parameters={"representation": "quadrature"},
             ),
         )
         self.update_Zetas()


### PR DESCRIPTION
The the microstructure in the mechanics mesh are in a quadrature space we cannot interpolate these into the fine ep mesh. Therefore we need to recreate the microstructure using cardiac-geometries. To do this we need to also refine the facet function which is what we do in this PR.