### PR TITLE
Performance improvements for projections and interpolations

### DIFF
--- a/.cspell_dict.txt
+++ b/.cspell_dict.txt
@@ -164,6 +164,7 @@ Hookean
 hs
 hsp
 hssp
+hstack
 hyperelastic
 icntl
 iF

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ select = B,C,E,F,W,T4
 test = pytest
 
 [tool:pytest]
-addopts = --cov=src/simcardems --cov-report html --cov-report xml --cov-report term-missing -v
+addopts = --cov=simcardems --cov-report html --cov-report xml --cov-report term-missing -v
 testpaths =
     tests
 markers =

--- a/src/simcardems/em_model.py
+++ b/src/simcardems/em_model.py
@@ -70,15 +70,15 @@ class EMCoupling:
 
     def coupling_to_mechanics(self):
         logger.debug("Interpolate mechanics")
-        self.XS_mech.assign(dolfin.interpolate(self.XS_ep, self.V_mech))
-        self.XW_mech.assign(dolfin.interpolate(self.XW_ep, self.V_mech))
+        self.XS_mech.interpolate(self.XS_ep)
+        self.XW_mech.interpolate(self.XW_ep)
         logger.debug("Done interpolating mechanics")
 
     def mechanics_to_coupling(self):
         logger.debug("Interpolate EP")
-        self.lmbda_ep.assign(dolfin.interpolate(self.lmbda_mech, self.V_ep))
-        self.Zetas_ep.assign(dolfin.interpolate(self.Zetas_mech, self.V_ep))
-        self.Zetaw_ep.assign(dolfin.interpolate(self.Zetaw_mech, self.V_ep))
+        self.lmbda_ep.interpolate(self.lmbda_mech)
+        self.Zetas_ep.interpolate(self.Zetas_mech)
+        self.Zetaw_ep.interpolate(self.Zetaw_mech)
         logger.debug("Done interpolating EP")
 
     def coupling_to_ep(self):

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -54,7 +54,7 @@ class Projector:
             u (dolfin.Function): The function to project into
             f (ufl.core.expr.Expr): The ufl expression to project
         """
-b = dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b)
+        b = dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b)
         self.solver.solve(u.vector(), b.vector())
 
 

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -26,11 +26,11 @@ class Projector:
         """
         u = dolfin.TrialFunction(V)
         self._v = dolfin.TestFunction(V)
-        self._dx = dolfin.Measure("dx", domain=V.mesh)
+        self._dx = dolfin.Measure("dx", domain=V.mesh())
         self._b = dolfin.Function(V)
         self._A = dolfin.assemble(ufl.inner(u, self._v) * self._dx)
         lu_methods = dolfin.lu_solver_methods().keys()
-        krylov_methods = dolfin.krylov_solver_methods()
+        krylov_methods = dolfin.krylov_solver_methods().keys()
         if solver_type == "lu" or solver_type in lu_methods:
             if preconditioner_type != "default":
                 raise RuntimeError("LUSolver cannot be preconditioned")
@@ -56,7 +56,7 @@ class Projector:
             u (dolfin.Function): The function to project into
             f (ufl.core.expr.Expr): The ufl expression to project
         """
-        dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b)
+        dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b.vector())
         self.solver.solve(u.vector(), self._b.vector())
 
 
@@ -268,7 +268,6 @@ class LandModel(pulse.ActiveModel):
         self._projector.project(self.lmbda, dolfin.sqrt(f**2))
         self.update_Zetas()
         self.update_Zetaw()
-        assert False
         return pulse.material.active_model.Wactive_transversally(
             Ta=self.Ta,
             C=C,

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -1,63 +1,10 @@
 from enum import Enum
 
 import dolfin
-import numpy
 import pulse
 import ufl
 
-
-class Projector:
-    def __init__(
-        self,
-        V: dolfin.FunctionSpace,
-        solver_type: str = "lu",
-        preconditioner_type: str = "default",
-    ):
-        """
-        Projection class caching solver and matrix assembly
-
-        Args:
-            V (dolfin.FunctionSpace): Function-space to project in to
-            solver_type (str, optional): Type of solver. Defaults to "lu".
-            preconditioner_type (str, optional): Type of preconditioner. Defaults to "default".
-
-        Raises:
-            RuntimeError: _description_
-        """
-        u = dolfin.TrialFunction(V)
-        self._v = dolfin.TestFunction(V)
-        self._dx = dolfin.Measure("dx", domain=V.mesh())
-        self._b = dolfin.Function(V)
-        self._A = dolfin.assemble(ufl.inner(u, self._v) * self._dx)
-        lu_methods = dolfin.lu_solver_methods().keys()
-        krylov_methods = dolfin.krylov_solver_methods().keys()
-        if solver_type == "lu" or solver_type in lu_methods:
-            if preconditioner_type != "default":
-                raise RuntimeError("LUSolver cannot be preconditioned")
-            self.solver = dolfin.LUSolver(self._A, "default")
-        elif solver_type in krylov_methods:
-            self.solver = dolfin.PETScKrylovSolver(
-                self._A,
-                solver_type,
-                preconditioner_type,
-            )
-        else:
-            raise RuntimeError(
-                f"Unknown solver type: {solver_type}, method has to be lu"
-                + f", or {numpy.hstack(lu_methods, krylov_methods)}",
-            )
-        self.solver.set_operator(self._A)
-
-    def project(self, u: dolfin.Function, f: ufl.core.expr.Expr):
-        """
-        Project `f` into `u`.
-
-        Args:
-            u (dolfin.Function): The function to project into
-            f (ufl.core.expr.Expr): The ufl expression to project
-        """
-        dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b.vector())
-        self.solver.solve(u.vector(), self._b.vector())
+from .utils import Projector
 
 
 class Scheme(str, Enum):

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -37,7 +37,9 @@ class Projector:
             self.solver = dolfin.LUSolver(self._A, "default")
         elif solver_type in krylov_methods:
             self.solver = dolfin.PETScKrylovSolver(
-                self._A, solver_type, preconditioner_type,
+                self._A,
+                solver_type,
+                preconditioner_type,
             )
         else:
             raise RuntimeError(

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -54,7 +54,7 @@ class Projector:
             u (dolfin.Function): The function to project into
             f (ufl.core.expr.Expr): The ufl expression to project
         """
-        b = dolfin.assemble(ufl.inner(f, self._v) * self.dx, tensor=self._b)
+b = dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b)
         self.solver.solve(u.vector(), b.vector())
 
 

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -1,13 +1,18 @@
 from enum import Enum
 
 import dolfin
+import numpy
 import pulse
 import ufl
-import numpy
 
 
-class Projector():
-    def __init__(self, V: dolfin.FunctionSpace, solver_type: str = "lu", preconditioner_type: str = "default"):
+class Projector:
+    def __init__(
+        self,
+        V: dolfin.FunctionSpace,
+        solver_type: str = "lu",
+        preconditioner_type: str = "default",
+    ):
         """
         Projection class caching solver and matrix assembly
 
@@ -32,11 +37,13 @@ class Projector():
             self.solver = dolfin.LUSolver(self._A, "default")
         elif solver_type in krylov_methods:
             self.solver = dolfin.PETScKrylovSolver(
-                self._A, solver_type, preconditioner_type)
+                self._A, solver_type, preconditioner_type,
+            )
         else:
             raise RuntimeError(
                 f"Unknown solver type: {solver_type}, method has to be lu"
-                + f", or {numpy.hstack(lu_methods, krylov_methods)}")
+                + f", or {numpy.hstack(lu_methods, krylov_methods)}",
+            )
         self.solver.set_operator(self._A)
 
     def project(self, u: dolfin.Function, f: ufl.core.expr.Expr):
@@ -259,7 +266,7 @@ class LandModel(pulse.ActiveModel):
         self._projector.project(self.lmbda, dolfin.sqrt(f**2))
         self.update_Zetas()
         self.update_Zetaw()
-        assert (False)
+        assert False
         return pulse.material.active_model.Wactive_transversally(
             Ta=self.Ta,
             C=C,

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -54,8 +54,8 @@ class Projector:
             u (dolfin.Function): The function to project into
             f (ufl.core.expr.Expr): The ufl expression to project
         """
-        b = dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b)
-        self.solver.solve(u.vector(), b.vector())
+        dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b)
+        self.solver.solve(u.vector(), self._b.vector())
 
 
 class Scheme(str, Enum):

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -3,6 +3,52 @@ from enum import Enum
 import dolfin
 import pulse
 import ufl
+import numpy
+
+
+class Projector():
+    def __init__(self, V: dolfin.FunctionSpace, solver_type: str = "lu", preconditioner_type: str = "default"):
+        """
+        Projection class caching solver and matrix assembly
+
+        Args:
+            V (dolfin.FunctionSpace): Function-space to project in to
+            solver_type (str, optional): Type of solver. Defaults to "lu".
+            preconditioner_type (str, optional): Type of preconditioner. Defaults to "default".
+
+        Raises:
+            RuntimeError: _description_
+        """
+        u = dolfin.TrialFunction(V)
+        self._v = dolfin.TestFunction(V)
+        self._dx = dolfin.Measure("dx", domain=V.mesh)
+        self._b = dolfin.Function(V)
+        self._A = dolfin.assemble(ufl.inner(u, self._v) * self._dx)
+        lu_methods = dolfin.lu_solver_methods().keys()
+        krylov_methods = dolfin.krylov_solver_methods()
+        if solver_type == "lu" or solver_type in lu_methods:
+            if preconditioner_type != "default":
+                raise RuntimeError("LUSolver cannot be preconditioned")
+            self.solver = dolfin.LUSolver(self._A, "default")
+        elif solver_type in krylov_methods:
+            self.solver = dolfin.PETScKrylovSolver(
+                self._A, solver_type, preconditioner_type)
+        else:
+            raise RuntimeError(
+                f"Unknown solver type: {solver_type}, method has to be lu"
+                + f", or {numpy.hstack(lu_methods, krylov_methods)}")
+        self.solver.set_operator(self._A)
+
+    def project(self, u: dolfin.Function, f: ufl.core.expr.Expr):
+        """
+        Project `f` into `u`.
+
+        Args:
+            u (dolfin.Function): The function to project into
+            f (ufl.core.expr.Expr): The ufl expression to project
+        """
+        b = dolfin.assemble(ufl.inner(f, self._v) * self.dx, tensor=self._b)
+        self.solver.solve(u.vector(), b.vector())
 
 
 class Scheme(str, Enum):
@@ -70,6 +116,7 @@ class LandModel(pulse.ActiveModel):
             self.Zetaw_prev.assign(Zetaw)
 
         self.Ta_current = dolfin.Function(self.function_space, name="Ta")
+        self._projector = Projector(self.function_space)
 
     @property
     def dLambda(self):
@@ -179,7 +226,7 @@ class LandModel(pulse.ActiveModel):
         self.Zetas_prev.vector()[:] = self.Zetas.vector()
         self.Zetaw_prev.vector()[:] = self.Zetaw.vector()
         self.lmbda_prev.vector()[:] = self.lmbda.vector()
-        self.Ta_current.assign(dolfin.project(self.Ta, self.function_space))
+        self._projector.project(self.Ta_current, self.Ta)
 
     @property
     def Ta(self):
@@ -209,10 +256,10 @@ class LandModel(pulse.ActiveModel):
 
         C = F.T * F
         f = F * self.f0
-        self.lmbda.assign(dolfin.project(dolfin.sqrt(f**2), self.function_space))
+        self._projector.project(self.lmbda, dolfin.sqrt(f**2))
         self.update_Zetas()
         self.update_Zetaw()
-
+        assert (False)
         return pulse.material.active_model.Wactive_transversally(
             Ta=self.Ta,
             C=C,

--- a/src/simcardems/mechanics_model.py
+++ b/src/simcardems/mechanics_model.py
@@ -3,7 +3,6 @@ import typing
 
 import dolfin
 import pulse
-from mpi4py import MPI
 
 from . import boundary_conditions
 from . import config
@@ -37,9 +36,9 @@ class ContinuationBasedMechanicsProblem(pulse.MechanicsProblem):
             s0, s1 = self.old_states
 
             denominator = dolfin.assemble((c1 - c0) ** 2 * dolfin.dx)
-            max_denom = self.geometry.mesh.mpi_comm().allreduce(denominator, op=MPI.MAX)
+            # max_denom = self.geometry.mesh.mpi_comm().allreduce(denominator, op=MPI.MAX)
 
-            if max_denom > tol:
+            if denominator > tol:
                 numerator = dolfin.assemble((control - c0) ** 2 * dolfin.dx)
                 delta = numerator / denominator
                 self.state.vector().zero()

--- a/src/simcardems/utils.py
+++ b/src/simcardems/utils.py
@@ -4,6 +4,7 @@ import typing
 from pathlib import Path
 
 import dolfin
+import numpy as np
 import ufl
 
 PathLike = typing.Union[os.PathLike, str]
@@ -30,6 +31,60 @@ def getLogger(name):
 
 
 logger = getLogger(__name__)
+
+
+class Projector:
+    def __init__(
+        self,
+        V: dolfin.FunctionSpace,
+        solver_type: str = "lu",
+        preconditioner_type: str = "default",
+    ):
+        """
+        Projection class caching solver and matrix assembly
+
+        Args:
+            V (dolfin.FunctionSpace): Function-space to project in to
+            solver_type (str, optional): Type of solver. Defaults to "lu".
+            preconditioner_type (str, optional): Type of preconditioner. Defaults to "default".
+
+        Raises:
+            RuntimeError: _description_
+        """
+        u = dolfin.TrialFunction(V)
+        self._v = dolfin.TestFunction(V)
+        self._dx = dolfin.Measure("dx", domain=V.mesh())
+        self._b = dolfin.Function(V)
+        self._A = dolfin.assemble(ufl.inner(u, self._v) * self._dx)
+        lu_methods = dolfin.lu_solver_methods().keys()
+        krylov_methods = dolfin.krylov_solver_methods().keys()
+        if solver_type == "lu" or solver_type in lu_methods:
+            if preconditioner_type != "default":
+                raise RuntimeError("LUSolver cannot be preconditioned")
+            self.solver = dolfin.LUSolver(self._A, "default")
+        elif solver_type in krylov_methods:
+            self.solver = dolfin.PETScKrylovSolver(
+                self._A,
+                solver_type,
+                preconditioner_type,
+            )
+        else:
+            raise RuntimeError(
+                f"Unknown solver type: {solver_type}, method has to be lu"
+                + f", or {np.hstack(lu_methods, krylov_methods)}",
+            )
+        self.solver.set_operator(self._A)
+
+    def project(self, u: dolfin.Function, f: ufl.core.expr.Expr):
+        """
+        Project `f` into `u`.
+
+        Args:
+            u (dolfin.Function): The function to project into
+            f (ufl.core.expr.Expr): The ufl expression to project
+        """
+        dolfin.assemble(ufl.inner(f, self._v) * self._dx, tensor=self._b.vector())
+        self.solver.solve(u.vector(), self._b.vector())
 
 
 def enum2str(x, EnumCls):


### PR DESCRIPTION
Fixes #
- Instead of creating a new function every time with call `coupling_to_mechanics` and `mechanics_to_coupling`, use the function we want to assign to as input. Avoids one data copy per call.
- Create a projector for the `land_model`. This means that every time we want to call `update_prev` or `Wactive` we avoid:
  - Reassembling the matrix
  - Re-initializing a solver
The last change might also re-use the lu-factorization, (as far as I've understood petsc). 