### PR TITLE
Allow the initial guess for krylov solver to be nonzero

### DIFF
--- a/src/simcardems/newton_solver.py
+++ b/src/simcardems/newton_solver.py
@@ -83,8 +83,8 @@ class MechanicsNewtonSolver(dolfin.NewtonSolver):
             "absolute_tolerance": 1e-5,
             "maximum_iterations": 20,
             "report": False,
-            # },
             "krylov_solver": {
+                "nonzero_initial_guess": True,
                 "absolute_tolerance": 1e-10,
                 "relative_tolerance": 1e-10,
                 "maximum_iterations": 1000,


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Set the Krylov solver setting `nonzero_initial_guess` to True
  -
  -
