### PR TITLE
Add tolerance for dlambda

### DIFF
--- a/.cspell_dict.txt
+++ b/.cspell_dict.txt
@@ -243,6 +243,7 @@ leftbottom
 lightcoral
 linalg
 linestyle
+linf
 linspace
 lmbda
 loadtxt

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
 import dolfin
+import numpy as np
 import pulse
 import ufl
-import numpy as np
 
 from . import utils
 

--- a/src/simcardems/land_model.py
+++ b/src/simcardems/land_model.py
@@ -82,6 +82,8 @@ class LandModel(pulse.ActiveModel):
     def dLambda(self):
         logger.debug("Evaluate dLambda")
         self._dLambda.vector()[:] = self.lmbda.vector() - self.lmbda_prev.vector()
+        if self._dLambda.vector().norm("linf") < 1e-12:
+            self._dLambda.vector()[:] = 0.0
         return self._dLambda
 
     @property


### PR DESCRIPTION
Adding a tolerance in order for force dLambda to be zero if the value is close to machine precision. 
That way we will avoid having dLambda oscillating between positive and negative values.

A few questions to think about here. 

- First is that we take a norm of the vector, and check wether the norm is small. Some dofs might  have a value close to zero, while others might not. We could do something like
    ```python
     self._dLambda.vector()[np.where(np.abs(v.get_local()) < 1e-12)[0]] = 0.0
     ```
     instead, in order to set the value of those dofs to zero, but I am not sure if this is needed?
- Is a tolerance of 1e-12 sufficient?