### PR TITLE
Fix loading of benchmark results

### DIFF
--- a/docs/benchmark.ipynb
+++ b/docs/benchmark.ipynb
@@ -97,8 +97,11 @@
     "    if not results_file.is_file():\n",
     "        print(f\"Results does not exist for version {git_hash}\")\n",
     "        continue\n",
-    "    with open(results_file, \"r\") as f:\n",
-    "        data[git_hash] = json.load(f)\n",
+    "    value = json.loads(results_file.read_text())\n",
+    "    if \"mesh\" in value.keys():\n",
+    "        # We have the wrong file\n",
+    "        continue\n",
+    "    data[git_hash] = value\n",
     "        "
    ]
   },

--- a/src/simcardems/benchmark.py
+++ b/src/simcardems/benchmark.py
@@ -38,7 +38,7 @@ def main(outdir):
         runner.solve(T=config.T, save_freq=config.save_freq, show_progress_bar=False)
     data["solve_time"] = time.perf_counter() - t0
 
-    loader = simcardems.DataLoader(Path(outdir) / "results.h5")
+    loader = simcardems.DataLoader(Path(outdir) / "benchmark_results.h5")
 
     values = extract_traces(loader=loader)
     data.update(


### PR DESCRIPTION
It seems that with the most recent changes, the info about the mesh is saved to a json-file with the same name as the `.h5` file, which is `results.json`. Since we also save the results from the benchmark in this file, there is a conflict. 

There we will instead save the benchmark results to a file called `benchmark_results.h5` and continue to save the benchmark results in `results.json`
