### PR TITLE
Store version in results

### DIFF
--- a/src/simcardems/postprocess.py
+++ b/src/simcardems/postprocess.py
@@ -1,5 +1,7 @@
 import json
 from pathlib import Path
+from typing import Dict
+from typing import Union
 
 import ap_features as apf
 import dolfin
@@ -40,17 +42,22 @@ def plot_peaks(fname, data, threshold):
     fig.savefig(fname, dpi=300)
 
 
-def extract_traces(loader: DataLoader, reduction: str = "average"):
+def extract_traces(
+    loader: DataLoader,
+    reduction: str = "average",
+) -> Dict[str, Union[np.ndarray, Dict[str, np.ndarray]]]:
+
+    if loader.time_stamps is None:
+        logger.warning("No data found in loader")
+        return {}
 
     values = {
-        group: {
-            name: np.zeros(len(loader.time_stamps)) for name in names if name != "u"
-        }
+        group: {name: np.zeros(loader.size) for name in names if name != "u"}
         for group, names in loader.names.items()
     }
 
     if "u" in loader.names.get("mechanics", {}):
-        values["mechanics"]["u"] = np.zeros((len(loader.time_stamps), 3))
+        values["mechanics"]["u"] = np.zeros((loader.size, 3))
     values["time"] = np.array(loader.time_stamps, dtype=float)
 
     logger.info("Extract traces...")

--- a/tests/test_datacollector.py
+++ b/tests/test_datacollector.py
@@ -76,3 +76,9 @@ def test_DataLoader_load_empty_files_raises_ValueError(tmp_path, geo):
     collector = simcardems.DataCollector(tmp_path, geo=geo)
     with pytest.raises(ValueError):
         simcardems.DataLoader(collector.results_file)
+
+
+def test_DataCollector_store_version(tmp_path, geo):
+    collector = simcardems.DataCollector(tmp_path, geo=geo)
+    loader = simcardems.DataLoader(collector.results_file, empty_ok=True)
+    assert loader.version == simcardems.__version__


### PR DESCRIPTION
We want to save the version number inside the results. Here we store it as a dataset in the root of the results file.
Also added an option to make it OK to load an empty result file to make testing a bit easier.