### PR TITLE
Always save configuration to output directory when creating a runner

### DIFF
--- a/src/simcardems/runner.py
+++ b/src/simcardems/runner.py
@@ -1,3 +1,4 @@
+import json
 import typing
 from pathlib import Path
 
@@ -25,6 +26,8 @@ class Runner:
 
         self._config = config
         self.outdir.mkdir(exist_ok=True)
+        # Save config to outdir
+        (self.outdir / "config.json").write_text(json.dumps(self._config.as_dict()))
 
         from . import set_log_level
 


### PR DESCRIPTION
We do save the configuration in the `state.h5` file, but I think it is good to also save this in a json file whenever we instantiate the runner. 

