### PR TITLE
Load Literal from typing_extensions for lower python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     numpy
     scipy
     tqdm
+    typing-extensions
 python_requires = >=3.7
 package_dir =
     =src

--- a/src/simcardems/cli.py
+++ b/src/simcardems/cli.py
@@ -1,9 +1,9 @@
 import json
 import typing
-import typing_extensions
 from pathlib import Path
 
 import click
+import typing_extensions
 
 from . import models
 from . import postprocess as post

--- a/src/simcardems/cli.py
+++ b/src/simcardems/cli.py
@@ -1,5 +1,6 @@
 import json
 import typing
+import typing_extensions
 from pathlib import Path
 
 import click
@@ -191,7 +192,7 @@ def run(
     spring: float,
     traction: float,
     fix_right_plane: bool,
-    coupling_type: typing.Literal[
+    coupling_type: typing_extensions.Literal[
         "fully_coupled_ORdmm_Land",
         "explicit_ORdmm_Land",
         "pureEP_ORdmm_Land",

--- a/src/simcardems/config.py
+++ b/src/simcardems/config.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+import typing_extensions
 from dataclasses import dataclass
 
 import dolfin
@@ -34,7 +35,7 @@ class Config:
     popu_factors_file: utils.PathLike = ""
     disease_state: str = "healthy"
     dt_mech: float = 1.0
-    mechanics_solve_strategy: typing.Literal["fixed", "adaptive"] = "adaptive"
+    mechanics_solve_strategy: typing_extensions.Literal["fixed", "adaptive"] = "adaptive"
     # mechanics_ode_scheme: land_model.Scheme = land_model.Scheme.analytic
     ep_ode_scheme: str = "GRL1"
     ep_preconditioner: str = "sor"
@@ -43,7 +44,7 @@ class Config:
     mechanics_use_continuation: bool = False
     mechanics_use_custom_newton_solver: bool = False
     PCL: float = 1000
-    coupling_type: typing.Literal[
+    coupling_type: typing_extensions.Literal[
         "fully_coupled_ORdmm_Land",
         "explicit_ORdmm_Land",
         "pureEP_ORdmm_Land",

--- a/src/simcardems/config.py
+++ b/src/simcardems/config.py
@@ -36,7 +36,8 @@ class Config:
     disease_state: str = "healthy"
     dt_mech: float = 1.0
     mechanics_solve_strategy: typing_extensions.Literal[
-        "fixed", "adaptive",
+        "fixed",
+        "adaptive",
     ] = "adaptive"
     # mechanics_ode_scheme: land_model.Scheme = land_model.Scheme.analytic
     ep_ode_scheme: str = "GRL1"

--- a/src/simcardems/config.py
+++ b/src/simcardems/config.py
@@ -1,9 +1,9 @@
 import logging
 import typing
-import typing_extensions
 from dataclasses import dataclass
 
 import dolfin
+import typing_extensions
 
 from . import utils
 
@@ -35,7 +35,9 @@ class Config:
     popu_factors_file: utils.PathLike = ""
     disease_state: str = "healthy"
     dt_mech: float = 1.0
-    mechanics_solve_strategy: typing_extensions.Literal["fixed", "adaptive"] = "adaptive"
+    mechanics_solve_strategy: typing_extensions.Literal[
+        "fixed", "adaptive",
+    ] = "adaptive"
     # mechanics_ode_scheme: land_model.Scheme = land_model.Scheme.analytic
     ep_ode_scheme: str = "GRL1"
     ep_preconditioner: str = "sor"

--- a/src/simcardems/datacollector.py
+++ b/src/simcardems/datacollector.py
@@ -3,7 +3,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict
 from typing import List
-from typing import Literal
+from typing_extensions import Literal
 from typing import Optional
 from typing import Tuple
 from typing import Union

--- a/src/simcardems/datacollector.py
+++ b/src/simcardems/datacollector.py
@@ -3,7 +3,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict
 from typing import List
-from typing_extensions import Literal
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -16,6 +15,7 @@ import pulse
 from dolfin import FiniteElement  # noqa: F401
 from dolfin import tetrahedron  # noqa: F401
 from dolfin import VectorElement  # noqa: F401
+from typing_extensions import Literal
 
 from . import utils
 from .geometry import BaseGeometry

--- a/src/simcardems/runner.py
+++ b/src/simcardems/runner.py
@@ -26,7 +26,15 @@ class Runner:
         self._config = config
         self.outdir.mkdir(exist_ok=True)
         # Save config to outdir
-        (self.outdir / "config.json").write_text(json.dumps(self._config.as_dict()))
+
+        def serialize(x):
+            if isinstance(x, Path):
+                return x.as_posix()
+            return x
+
+        (self.outdir / "config.json").write_text(
+            json.dumps(self._config.as_dict(), default=serialize),
+        )
 
         from . import set_log_level
 


### PR DESCRIPTION
The function `typing.Literal` is not available for Python < 3.8. 

## Proposed Changes

  - Load `Literal` from `typing_extensions` instead of `typing`
  -
  -
