### PR TITLE
Save state file every 10 beats

### DIFF
--- a/src/simcardems/runner.py
+++ b/src/simcardems/runner.py
@@ -172,6 +172,9 @@ class Runner:
         save_freq: int = Config.save_freq,
         show_progress_bar: bool = Config.show_progress_bar,
         st_progress: typing.Any = None,
+        default_save_condition: typing.Callable[[int, float, float], bool] = (
+            lambda i, T, dt: i > 0 and T >= 40000 and i % int(10000 / dt) == 0
+        ),
     ):
         save_it = int(save_freq / self._dt)
         self._setup_time_stepper(T, use_ns=True, st_progress=st_progress)
@@ -200,7 +203,7 @@ class Runner:
                 self.store()
 
             # Save state every 10 beats if simulation is longer than 40 sec
-            if i > 0 and T >= 40000 and i % int(10000 / self._dt) == 0:
+            if default_save_condition(i, T, self._dt):
                 self.coupling.save_state(
                     path=self.outdir.joinpath(f"state_{int(i*self._dt/1000)}beat.h5"),
                     config=self._config,

--- a/src/simcardems/runner.py
+++ b/src/simcardems/runner.py
@@ -199,6 +199,13 @@ class Runner:
             if i % save_it == 0:
                 self.store()
 
+            # Save state every 10 beats if simulation is longer than 40 sec
+            if i > 0 and T >= 40000 and i % int(10000 / self._dt) == 0:
+                self.coupling.save_state(
+                    path=self.outdir.joinpath(f"state_{int(i*self._dt/1000)}beat.h5"),
+                    config=self._config,
+                )
+
         self.save_state()
 
 


### PR DESCRIPTION
Save state to file for every 10 beats, if the simulation is longer than 40 beats. 
This creates an intermediate starting point for long simulations and backup in case of errors. 

## Proposed Changes

  - check if T>40000 ms
  - save state file with number of beats in the filename
  -
