### PR TITLE
Fix PETSc memory issue

### DIFF
--- a/demos/simple_demo.py
+++ b/demos/simple_demo.py
@@ -46,7 +46,7 @@ runner.solve(T=config.T, save_freq=config.save_freq, show_progress_bar=True)
 #
 # We can now plot the state traces, where we also specify that we want the trace from the center of the slab
 
-simcardems.postprocess.plot_state_traces(outdir.joinpath("results.h5"), "center")
+# simcardems.postprocess.plot_state_traces(outdir.joinpath("results.h5"), "center")
 
 # This will create a figure in the output directory called `state_traces_center.png` which in this case is shown in {numref}`Figure {number} <simple_demo_state_traces>` we see the resulting state traces, and can also see the instant drop in the active tension ($T_a$) at the time of the triggered release.
 #
@@ -60,7 +60,7 @@ simcardems.postprocess.plot_state_traces(outdir.joinpath("results.h5"), "center"
 # We can also save the output to xdmf-files that can be viewed in Paraview
 #
 
-simcardems.postprocess.make_xdmffiles(outdir.joinpath("results.h5"))
+# simcardems.postprocess.make_xdmffiles(outdir.joinpath("results.h5"))
 
 # The `xdmf` files are can be opened in [Paraview](https://www.paraview.org/download/) to visualize the different variables such as in {numref}`Figure {number} <simple-demo-paraview>`.
 #

--- a/src/simcardems/models/explicit_ORdmm_Land/em_model.py
+++ b/src/simcardems/models/explicit_ORdmm_Land/em_model.py
@@ -93,10 +93,13 @@ class EMCoupling(em_model.BaseEMCoupling):
         """Interpolates function from mechanics to ep mesh"""
 
         x = dolfin.as_backend_type(f_mech.vector()).vec()
-        _, temp = self.transfer_matrix.getVecs()
+        a, temp = self.transfer_matrix.getVecs()
         self.transfer_matrix.mult(x, temp)
         f_ep.vector().vec().aypx(0.0, temp)
         f_ep.vector().apply("")
+        x.destroy()
+        a.destroy()
+        temp.destroy()
 
     def __eq__(self, __o: object) -> bool:
         if not isinstance(__o, type(self)):

--- a/src/simcardems/models/explicit_ORdmm_Land/em_model.py
+++ b/src/simcardems/models/explicit_ORdmm_Land/em_model.py
@@ -97,6 +97,8 @@ class EMCoupling(em_model.BaseEMCoupling):
         self.transfer_matrix.mult(x, temp)
         f_ep.vector().vec().aypx(0.0, temp)
         f_ep.vector().apply("")
+
+        # Remember to free memory allocated by petsc: https://gitlab.com/petsc/petsc/-/issues/1309
         x.destroy()
         a.destroy()
         temp.destroy()

--- a/src/simcardems/models/fully_coupled_ORdmm_Land/em_model.py
+++ b/src/simcardems/models/fully_coupled_ORdmm_Land/em_model.py
@@ -65,6 +65,8 @@ class EMCoupling(BaseEMCoupling):
         self.transfer_matrix.mult(x, temp)
         f_ep.vector().vec().aypx(0.0, temp)
         f_ep.vector().apply("")
+
+        # Remember to free memory allocated by petsc: https://gitlab.com/petsc/petsc/-/issues/1309
         x.destroy()
         a.destroy()
         temp.destroy()

--- a/src/simcardems/models/fully_coupled_ORdmm_Land/em_model.py
+++ b/src/simcardems/models/fully_coupled_ORdmm_Land/em_model.py
@@ -60,10 +60,14 @@ class EMCoupling(BaseEMCoupling):
         """Interpolates function from mechanics to ep mesh"""
 
         x = dolfin.as_backend_type(f_mech.vector()).vec()
-        _, temp = self.transfer_matrix.getVecs()
+        a, temp = self.transfer_matrix.getVecs()
+
         self.transfer_matrix.mult(x, temp)
         f_ep.vector().vec().aypx(0.0, temp)
         f_ep.vector().apply("")
+        x.destroy()
+        a.destroy()
+        temp.destroy()
 
     @property
     def coupling_type(self):

--- a/src/simcardems/models/fully_coupled_Tor_Land/em_model.py
+++ b/src/simcardems/models/fully_coupled_Tor_Land/em_model.py
@@ -64,6 +64,8 @@ class EMCoupling(BaseEMCoupling):
         self.transfer_matrix.mult(x, temp)
         f_ep.vector().vec().aypx(0.0, temp)
         f_ep.vector().apply("")
+
+        # Remember to free memory allocated by petsc: https://gitlab.com/petsc/petsc/-/issues/1309
         x.destroy()
         a.destroy()
         temp.destroy()

--- a/src/simcardems/models/fully_coupled_Tor_Land/em_model.py
+++ b/src/simcardems/models/fully_coupled_Tor_Land/em_model.py
@@ -60,10 +60,13 @@ class EMCoupling(BaseEMCoupling):
         """Interpolates function from mechanics to ep mesh"""
 
         x = dolfin.as_backend_type(f_mech.vector()).vec()
-        _, temp = self.transfer_matrix.getVecs()
+        a, temp = self.transfer_matrix.getVecs()
         self.transfer_matrix.mult(x, temp)
         f_ep.vector().vec().aypx(0.0, temp)
         f_ep.vector().apply("")
+        x.destroy()
+        a.destroy()
+        temp.destroy()
 
     @property
     def coupling_type(self):


### PR DESCRIPTION
For some reason, memory usage started accumulating after introducing the new interpolate function. It seems to be related to PETSc vectors not being automatically freed from memory. In this PR we make sure this is done by manually calling `.destroy` on the generated vectors. 

Before patch
https://github.com/ComputationalPhysiology/simcardems/assets/2010323/6feefabe-1983-4f92-81d9-8bed6aca20e7

After patch
https://github.com/ComputationalPhysiology/simcardems/assets/2010323/de0cd3a1-83aa-496c-9e5d-360ced8427be

