### PR TITLE
Set upper bound on numpy to 1.21.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "fenics-pulse",
     "h5py",
     "matplotlib",
-    "numpy",
+    "numpy<=1.21.5",
     "scipy",
     "tqdm",
     "typing-extensions",


### PR DESCRIPTION
Tests seems to be failing with numpy 2.0, so lets just set an upper bound.